### PR TITLE
Add NET_RAW capability to looking-glass container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
       dockerfile: Dockerfile
     container_name: looking-glass
     restart: always
+    cap_add:
+      - NET_RAW
     network_mode: host
     env_file:
       - .env


### PR DESCRIPTION
This is needed otherwise the golang process is unable to make raw socket connections needed to ping


Ran into an issue where using the `ping` tool would error out with the following message
```
2025/10/22 10:42:37 [Recovery] 2025/10/22 - 10:42:37 panic recovered:
listen ip4:icmp 0.0.0.0: socket: operation not permitted
```

Figured that we needed to add the NET_RAW capability to the docker container (or the golang binary).

I can confirm that this work for my use-case. 